### PR TITLE
feat: #2 Integrate project repo to CodeCov to understand the code coverage

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,3 +20,23 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        run: rustup update stable
+      - name: Install cargo-llm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate Code Coverage
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+      - name: Upload coverage to CodeCov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          fail_ci_if_error: true
+      - name: Verify Code Coverage Limit
+        run: cargo llvm-cov --workspace --all-features  --fail-under-lines 60 --fail-under-functions 50 --fail-under-regions 50 -- tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,6 +37,5 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
-          fail_ci_if_error: true
       - name: Verify Code Coverage Limit
         run: cargo llvm-cov --workspace --all-features  --fail-under-lines 60 --fail-under-functions 60 --fail-under-regions 40 -- tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,4 +39,4 @@ jobs:
           files: lcov.info
           fail_ci_if_error: true
       - name: Verify Code Coverage Limit
-        run: cargo llvm-cov --workspace --all-features  --fail-under-lines 60 --fail-under-functions 50 --fail-under-regions 50 -- tests
+        run: cargo llvm-cov --workspace --all-features  --fail-under-lines 60 --fail-under-functions 60 --fail-under-regions 40 -- tests

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ cargo test hello_test
 ```
 
 ## Code Coverage
-For understanding the code coverage, we are using [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov). We are targetting 50% line coverage, 50% region coverage and 50% function coverage. We will increase this threshold as the product development proceeds. We are uploading the code coverage data to the [CodeCov](https://app.codecov.io/gh/harsha-kadekar/subhasitas) 
+For understanding the code coverage, we are using [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov). We are targetting 60% line coverage, 40% region coverage and 60% function coverage. We will increase this threshold as the product development proceeds. We are uploading the code coverage data to the [CodeCov](https://app.codecov.io/gh/harsha-kadekar/subhasitas) 
 
 ```
 cargo +stable install cargo-llvm-cov --locked

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A simple service that can provide random subhasitas (maxims). Sanskrit: सुभाषित, subhāṣita.
 
+[![codecov](https://codecov.io/gh/harsha-kadekar/subhasitas/graph/badge.svg?token=UFZ5YSNFJU)](https://codecov.io/gh/harsha-kadekar/subhasitas)
+[![CI](https://github.com/harsha-kadekar/subhasitas/actions/workflows/rust.yml/badge.svg)](https://github.com/harsha-kadekar/subhasitas/actions/workflows/rust.yml)
+
+
 # Getting Started
 
 ## Environment setup
@@ -92,6 +96,22 @@ cargo test
 
 # Run a single test
 cargo test hello_test
+```
+
+## Code Coverage
+For understanding the code coverage, we are using [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov). We are targetting 50% line coverage, 50% region coverage and 50% function coverage. We will increase this threshold as the product development proceeds. We are uploading the code coverage data to the [CodeCov](https://app.codecov.io/gh/harsha-kadekar/subhasitas) 
+
+```
+cargo +stable install cargo-llvm-cov --locked
+
+# Displays the report in the stdout
+cargo llvm-cov --workspace --all-features  --fail-under-lines 50 --fail-under-functions 50 --fail-under-regions 50  -- tests
+
+# generates the html coverage report in folder target/llvm-cov/html/index.html
+cargo llvm-cov --html
+
+# generates the output file which will be uploaded to CodeCov during Github Actions
+cargo llvm-cov --lcov --output-path lcov.info
 ```
 
 ## Run


### PR DESCRIPTION
This is addressing issue #2 - to generate code coverage and also link it as part of github actions. The build should fail if it does not meet the set thresholds for code coverage. 